### PR TITLE
Add TypeScript message broker

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,0 +1,35 @@
+# TypeScript Broker Example
+
+This folder contains a minimal message broker implemented in TypeScript using only the Node.js standard library.
+
+## Scripts
+
+- `npm run build` – compile the TypeScript sources into `dist`.
+- `npm start` – run the compiled server.
+
+## API
+
+### POST /publish
+
+Body JSON:
+
+```
+{ "topic": "/topic/sub", "data": { ... } }
+```
+
+Publishes a message. Queues attached to the topic or any parent topic receive the message.
+
+### POST /attachQueue
+
+Body JSON:
+
+```
+{ "queueId": "myQueue", "topic": "/topic" }
+```
+
+Registers a queue to receive messages from a topic.
+
+### GET /get?queueId=myQueue
+
+Retrieves and clears messages for the specified queue.
+

--- a/typescript/dist/index.js
+++ b/typescript/dist/index.js
@@ -1,0 +1,98 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const http_1 = require("http");
+const url_1 = require("url");
+class Broker {
+    constructor() {
+        this.queues = new Map();
+    }
+    attachQueue(id, topic) {
+        const segments = this.parseTopic(topic);
+        this.queues.set(id, { topic: segments, messages: [] });
+    }
+    publish(topic, data) {
+        const segments = this.parseTopic(topic);
+        for (const [_, queue] of this.queues) {
+            if (this.topicMatches(queue.topic, segments)) {
+                queue.messages.push({ topic, data });
+            }
+        }
+    }
+    getMessages(id) {
+        const queue = this.queues.get(id);
+        if (!queue)
+            return [];
+        const messages = queue.messages.slice();
+        queue.messages.length = 0;
+        return messages;
+    }
+    parseTopic(topic) {
+        return topic.split('/').filter(Boolean);
+    }
+    topicMatches(queueTopic, messageTopic) {
+        if (queueTopic.length > messageTopic.length)
+            return false;
+        for (let i = 0; i < queueTopic.length; i++) {
+            if (queueTopic[i] !== messageTopic[i])
+                return false;
+        }
+        return true;
+    }
+}
+const broker = new Broker();
+function readBody(req) {
+    return new Promise((resolve, reject) => {
+        let data = '';
+        req.on('data', (chunk) => { data += chunk; });
+        req.on('end', () => {
+            try {
+                resolve(JSON.parse(data || '{}'));
+            }
+            catch (err) {
+                reject(err);
+            }
+        });
+        req.on('error', reject);
+    });
+}
+const server = (0, http_1.createServer)(async (req, res) => {
+    const url = new url_1.URL(req.url || '', `http://${req.headers.host}`);
+    try {
+        if (req.method === 'POST' && url.pathname === '/publish') {
+            const body = await readBody(req);
+            if (!body.topic)
+                throw new Error('Missing topic');
+            broker.publish(body.topic, body.data);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ok' }));
+        }
+        else if (req.method === 'POST' && url.pathname === '/attachQueue') {
+            const body = await readBody(req);
+            if (!body.queueId || !body.topic)
+                throw new Error('Missing parameters');
+            broker.attachQueue(body.queueId, body.topic);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ status: 'ok' }));
+        }
+        else if (req.method === 'GET' && url.pathname === '/get') {
+            const queueId = url.searchParams.get('queueId');
+            if (!queueId)
+                throw new Error('Missing queueId');
+            const messages = broker.getMessages(queueId);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ messages }));
+        }
+        else {
+            res.writeHead(404, { 'Content-Type': 'text/plain' });
+            res.end('Not found');
+        }
+    }
+    catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: err.message }));
+    }
+});
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+    console.log(`Broker server running on port ${PORT}`);
+});

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "typescript",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,99 @@
+import { createServer, IncomingMessage, ServerResponse } from 'http';
+import { URL } from 'url';
+
+interface Queue {
+  topic: string[];
+  messages: any[];
+}
+
+class Broker {
+  private queues: Map<string, Queue> = new Map();
+
+  attachQueue(id: string, topic: string) {
+    const segments = this.parseTopic(topic);
+    this.queues.set(id, { topic: segments, messages: [] });
+  }
+
+  publish(topic: string, data: any) {
+    const segments = this.parseTopic(topic);
+    for (const [_, queue] of this.queues) {
+      if (this.topicMatches(queue.topic, segments)) {
+        queue.messages.push({ topic, data });
+      }
+    }
+  }
+
+  getMessages(id: string): any[] {
+    const queue = this.queues.get(id);
+    if (!queue) return [];
+    const messages = queue.messages.slice();
+    queue.messages.length = 0;
+    return messages;
+  }
+
+  private parseTopic(topic: string): string[] {
+    return topic.split('/').filter(Boolean);
+  }
+
+  private topicMatches(queueTopic: string[], messageTopic: string[]): boolean {
+    if (queueTopic.length > messageTopic.length) return false;
+    for (let i = 0; i < queueTopic.length; i++) {
+      if (queueTopic[i] !== messageTopic[i]) return false;
+    }
+    return true;
+  }
+}
+
+const broker = new Broker();
+
+function readBody(req: any): Promise<any> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: any) => { data += chunk; });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(data || '{}'));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+const server = createServer(async (req: any, res: any) => {
+  const url = new URL(req.url || '', `http://${req.headers.host}`);
+  try {
+    if (req.method === 'POST' && url.pathname === '/publish') {
+      const body = await readBody(req);
+      if (!body.topic) throw new Error('Missing topic');
+      broker.publish(body.topic, body.data);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    } else if (req.method === 'POST' && url.pathname === '/attachQueue') {
+      const body = await readBody(req);
+      if (!body.queueId || !body.topic) throw new Error('Missing parameters');
+      broker.attachQueue(body.queueId, body.topic);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+    } else if (req.method === 'GET' && url.pathname === '/get') {
+      const queueId = url.searchParams.get('queueId');
+      if (!queueId) throw new Error('Missing queueId');
+      const messages = broker.getMessages(queueId);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ messages }));
+    } else {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not found');
+    }
+  } catch (err: any) {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: err.message }));
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Broker server running on port ${PORT}`);
+});
+

--- a/typescript/src/types.d.ts
+++ b/typescript/src/types.d.ts
@@ -1,0 +1,3 @@
+declare module 'http';
+declare module 'url';
+declare var process: any;

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  }
+}


### PR DESCRIPTION
## Summary
- implement a minimal message broker with publish, attachQueue and get operations in TypeScript
- provide build configuration and basic usage instructions

## Testing
- `npm run build`
- `npm start` (manual run to confirm server starts)

------
https://chatgpt.com/codex/tasks/task_e_686b6a13630083288f9ce7699490adbf