### PR TITLE
Add Express server and Rust load tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # ThinBroker
+
+This repository contains a minimal message broker written in TypeScript using the Express framework.  Messages can be published to topics and consumed from attached queues.
+
+The `typescript` directory holds the server implementation.  Build the server with
+
+```sh
+cd typescript
+npm run build
+npm start
+```
+
+A simple load tester is provided in the `broker_tester` directory.  It is a Rust command line program that sends messages to the broker using multiple threads and reports latency percentiles.
+
+Run it with:
+
+```sh
+cargo run --release -- <server_url> <threads> <messages_per_thread>
+```
+
+The output displays the p50, p90 and p99 response times in milliseconds.

--- a/broker_tester/Cargo.toml
+++ b/broker_tester/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "broker_tester"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+reqwest = { version = "0.11", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }

--- a/broker_tester/src/main.rs
+++ b/broker_tester/src/main.rs
@@ -1,0 +1,65 @@
+use std::env;
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Instant;
+
+use reqwest::blocking::Client;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct PublishRequest<'a> {
+    topic: &'a str,
+    data: &'a str,
+}
+
+fn percentile(data: &Vec<u128>, pct: f64) -> u128 {
+    if data.is_empty() {
+        return 0;
+    }
+    let idx = ((pct / 100.0) * ((data.len() - 1) as f64)).round() as usize;
+    data[idx]
+}
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 4 {
+        eprintln!("Usage: {} <server_url> <threads> <messages_per_thread>", args[0]);
+        return;
+    }
+    let url = args[1].clone();
+    let threads: usize = args[2].parse().expect("invalid threads");
+    let messages: usize = args[3].parse().expect("invalid messages");
+
+    let times: Arc<Mutex<Vec<u128>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut handles = Vec::new();
+    for _ in 0..threads {
+        let times = Arc::clone(&times);
+        let url = url.clone();
+        handles.push(thread::spawn(move || {
+            let client = Client::new();
+            for _ in 0..messages {
+                let start = Instant::now();
+                let _ = client
+                    .post(format!("{}/publish", url))
+                    .json(&PublishRequest {
+                        topic: "/bench",
+                        data: "x",
+                    })
+                    .send();
+                let elapsed = start.elapsed().as_millis();
+                times.lock().unwrap().push(elapsed);
+            }
+        }));
+    }
+
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let mut data = times.lock().unwrap();
+    data.sort();
+
+    println!("p50: {} ms", percentile(&data, 50.0));
+    println!("p90: {} ms", percentile(&data, 90.0));
+    println!("p99: {} ms", percentile(&data, 99.0));
+}

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,6 +1,6 @@
 # TypeScript Broker Example
 
-This folder contains a minimal message broker implemented in TypeScript using only the Node.js standard library.
+This folder contains a minimal message broker implemented in TypeScript using the Express framework.
 
 ## Scripts
 
@@ -32,4 +32,3 @@ Registers a queue to receive messages from a topic.
 ### GET /get?queueId=myQueue
 
 Retrieves and clears messages for the specified queue.
-

--- a/typescript/dist/index.js
+++ b/typescript/dist/index.js
@@ -1,7 +1,9 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-const http_1 = require("http");
-const url_1 = require("url");
+const express_1 = __importDefault(require("express"));
 class Broker {
     constructor() {
         this.queues = new Map();
@@ -12,7 +14,7 @@ class Broker {
     }
     publish(topic, data) {
         const segments = this.parseTopic(topic);
-        for (const [_, queue] of this.queues) {
+        for (const [, queue] of this.queues) {
             if (this.topicMatches(queue.topic, segments)) {
                 queue.messages.push({ topic, data });
             }
@@ -40,59 +42,36 @@ class Broker {
     }
 }
 const broker = new Broker();
-function readBody(req) {
-    return new Promise((resolve, reject) => {
-        let data = '';
-        req.on('data', (chunk) => { data += chunk; });
-        req.on('end', () => {
-            try {
-                resolve(JSON.parse(data || '{}'));
-            }
-            catch (err) {
-                reject(err);
-            }
-        });
-        req.on('error', reject);
-    });
-}
-const server = (0, http_1.createServer)(async (req, res) => {
-    const url = new url_1.URL(req.url || '', `http://${req.headers.host}`);
-    try {
-        if (req.method === 'POST' && url.pathname === '/publish') {
-            const body = await readBody(req);
-            if (!body.topic)
-                throw new Error('Missing topic');
-            broker.publish(body.topic, body.data);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ status: 'ok' }));
-        }
-        else if (req.method === 'POST' && url.pathname === '/attachQueue') {
-            const body = await readBody(req);
-            if (!body.queueId || !body.topic)
-                throw new Error('Missing parameters');
-            broker.attachQueue(body.queueId, body.topic);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ status: 'ok' }));
-        }
-        else if (req.method === 'GET' && url.pathname === '/get') {
-            const queueId = url.searchParams.get('queueId');
-            if (!queueId)
-                throw new Error('Missing queueId');
-            const messages = broker.getMessages(queueId);
-            res.writeHead(200, { 'Content-Type': 'application/json' });
-            res.end(JSON.stringify({ messages }));
-        }
-        else {
-            res.writeHead(404, { 'Content-Type': 'text/plain' });
-            res.end('Not found');
-        }
+const app = (0, express_1.default)();
+app.use(express_1.default.json());
+app.post('/publish', (req, res) => {
+    const { topic, data } = req.body || {};
+    if (!topic) {
+        res.status(400).json({ error: 'Missing topic' });
+        return;
     }
-    catch (err) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ error: err.message }));
+    broker.publish(topic, data);
+    res.json({ status: 'ok' });
+});
+app.post('/attachQueue', (req, res) => {
+    const { queueId, topic } = req.body || {};
+    if (!queueId || !topic) {
+        res.status(400).json({ error: 'Missing parameters' });
+        return;
     }
+    broker.attachQueue(queueId, topic);
+    res.json({ status: 'ok' });
+});
+app.get('/get', (req, res) => {
+    const queueId = req.query.queueId;
+    if (!queueId) {
+        res.status(400).json({ error: 'Missing queueId' });
+        return;
+    }
+    const messages = broker.getMessages(queueId);
+    res.json({ messages });
 });
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
+app.listen(PORT, () => {
     console.log(`Broker server running on port ${PORT}`);
 });

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,5 +10,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^4.18.2"
+  }
 }

--- a/typescript/src/types.d.ts
+++ b/typescript/src/types.d.ts
@@ -1,3 +1,4 @@
 declare module 'http';
 declare module 'url';
+declare module 'express';
 declare var process: any;


### PR DESCRIPTION
## Summary
- switch the TypeScript broker to Express
- include express dependency and types
- document new broker and tester
- add a Rust `broker_tester` CLI for load testing

## Testing
- `npx tsc`
- `cargo build --manifest-path broker_tester/Cargo.toml` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686b6c695ee483288965911822662d80