### PR TITLE
Add Rust broker server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ThinBroker
 
-This repository contains a minimal message broker written in TypeScript using the Express framework.  Messages can be published to topics and consumed from attached queues.
+This repository contains a minimal message broker.  A TypeScript implementation is provided using the Express framework and a Rust implementation using actix-web.  Messages can be published to topics and consumed from attached queues.
 
 The `typescript` directory holds the server implementation.  Build the server with
 
@@ -8,6 +8,12 @@ The `typescript` directory holds the server implementation.  Build the server wi
 cd typescript
 npm run build
 npm start
+```
+
+The `rust` directory contains the same broker implemented in Rust.  Build and run it with
+
+```sh
+cargo run --manifest-path rust/Cargo.toml
 ```
 
 A simple load tester is provided in the `broker_tester` directory.  It is a Rust command line program that sends messages to the broker using multiple threads and reports latency percentiles.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+actix-web = "4"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,39 @@
+# Rust Broker Example
+
+This folder contains a minimal message broker implemented in Rust using the `actix-web` framework.
+
+## Running
+
+Build and start the server with:
+
+```sh
+cargo run --manifest-path rust/Cargo.toml
+```
+
+## API
+
+The API matches the TypeScript implementation:
+
+### POST /publish
+
+Body JSON:
+
+```
+{ "topic": "/topic/sub", "data": { ... } }
+```
+
+Publishes a message. Queues attached to the topic or any parent topic receive the message.
+
+### POST /attachQueue
+
+Body JSON:
+
+```
+{ "queueId": "myQueue", "topic": "/topic" }
+```
+
+Registers a queue to receive messages from a topic.
+
+### GET /get?queueId=myQueue
+
+Retrieves and clears messages for the specified queue.

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,146 @@
+use actix_web::{web, App, HttpResponse, HttpServer, Responder};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Serialize)]
+struct Message {
+    topic: String,
+    data: serde_json::Value,
+}
+
+#[derive(Clone)]
+struct Queue {
+    topic: Vec<String>,
+    messages: Vec<Message>,
+}
+
+struct Broker {
+    queues: Mutex<HashMap<String, Queue>>,
+}
+
+impl Broker {
+    fn new() -> Self {
+        Broker {
+            queues: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn attach_queue(&self, id: String, topic: String) {
+        let segments = Self::parse_topic(&topic);
+        let mut qs = self.queues.lock().unwrap();
+        qs.insert(
+            id,
+            Queue {
+                topic: segments,
+                messages: Vec::new(),
+            },
+        );
+    }
+
+    fn publish(&self, topic: &str, data: serde_json::Value) {
+        let segments = Self::parse_topic(topic);
+        let mut qs = self.queues.lock().unwrap();
+        for queue in qs.values_mut() {
+            if Self::topic_matches(&queue.topic, &segments) {
+                queue.messages.push(Message {
+                    topic: topic.to_string(),
+                    data: data.clone(),
+                });
+            }
+        }
+    }
+
+    fn get_messages(&self, id: &str) -> Vec<Message> {
+        let mut qs = self.queues.lock().unwrap();
+        if let Some(queue) = qs.get_mut(id) {
+            let msgs = queue.messages.clone();
+            queue.messages.clear();
+            msgs
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn parse_topic(topic: &str) -> Vec<String> {
+        topic
+            .split('/')
+            .filter(|s| !s.is_empty())
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    fn topic_matches(queue_topic: &[String], message_topic: &[String]) -> bool {
+        if queue_topic.len() > message_topic.len() {
+            return false;
+        }
+        for (q, m) in queue_topic.iter().zip(message_topic.iter()) {
+            if q != m {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[derive(Deserialize)]
+struct PublishRequest {
+    topic: String,
+    data: serde_json::Value,
+}
+
+async fn publish(
+    broker: web::Data<Arc<Broker>>,
+    body: web::Json<PublishRequest>,
+) -> impl Responder {
+    broker.publish(&body.topic, body.data.clone());
+    HttpResponse::Ok().json(json!({"status": "ok"}))
+}
+
+#[derive(Deserialize)]
+struct AttachRequest {
+    #[serde(rename = "queueId")]
+    queue_id: String,
+    topic: String,
+}
+
+async fn attach_queue(
+    broker: web::Data<Arc<Broker>>,
+    body: web::Json<AttachRequest>,
+) -> impl Responder {
+    broker.attach_queue(body.queue_id.clone(), body.topic.clone());
+    HttpResponse::Ok().json(json!({"status": "ok"}))
+}
+
+async fn get_messages_handler(
+    broker: web::Data<Arc<Broker>>,
+    query: web::Query<HashMap<String, String>>,
+) -> impl Responder {
+    if let Some(id) = query.get("queueId") {
+        let msgs = broker.get_messages(id);
+        HttpResponse::Ok().json(json!({"messages": msgs}))
+    } else {
+        HttpResponse::BadRequest().json(json!({"error": "Missing queueId"}))
+    }
+}
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    let broker = Arc::new(Broker::new());
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|p| p.parse().ok())
+        .unwrap_or(3000);
+
+    HttpServer::new(move || {
+        App::new()
+            .app_data(web::Data::new(broker.clone()))
+            .route("/publish", web::post().to(publish))
+            .route("/attachQueue", web::post().to(attach_queue))
+            .route("/get", web::get().to(get_messages_handler))
+    })
+    .bind(("0.0.0.0", port))?
+    .run()
+    .await
+}


### PR DESCRIPTION
## Summary
- implement the broker server in Rust (`actix-web`)
- add instructions about the Rust server to the README
- include a README for the new Rust server

## Testing
- `cargo check --manifest-path rust/Cargo.toml` *(fails: failed to fetch crates index)*

------
https://chatgpt.com/codex/tasks/task_e_686b6ee50ca48328956d68734a0ff1be