### PR TITLE
Add basic functional test to load tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The `rust` directory contains the same broker implemented in Rust.  Build and ru
 cargo run --manifest-path rust/Cargo.toml
 ```
 
-A simple load tester is provided in the `broker_tester` directory.  It is a Rust command line program that sends messages to the broker using multiple threads and reports latency percentiles.
+A simple load tester is provided in the `broker_tester` directory.  It is a Rust command line program that first runs a basic functionality check on topics and message contents and then sends messages using multiple threads to report latency percentiles.
 
 Run it with:
 

--- a/broker_tester/Cargo.toml
+++ b/broker_tester/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"

--- a/broker_tester/src/main.rs
+++ b/broker_tester/src/main.rs
@@ -4,12 +4,31 @@ use std::thread;
 use std::time::Instant;
 
 use reqwest::blocking::Client;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[derive(Serialize)]
 struct PublishRequest<'a> {
     topic: &'a str,
     data: &'a str,
+}
+
+#[derive(Serialize)]
+struct AttachRequest<'a> {
+    #[serde(rename = "queueId")]
+    queue_id: &'a str,
+    topic: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ReceivedMessage {
+    topic: String,
+    data: Value,
+}
+
+#[derive(Deserialize)]
+struct GetResponse {
+    messages: Vec<ReceivedMessage>,
 }
 
 fn percentile(data: &Vec<u128>, pct: f64) -> u128 {
@@ -18,6 +37,51 @@ fn percentile(data: &Vec<u128>, pct: f64) -> u128 {
     }
     let idx = ((pct / 100.0) * ((data.len() - 1) as f64)).round() as usize;
     data[idx]
+}
+
+fn run_basic_test(base_url: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+
+    client
+        .post(format!("{}/attachQueue", base_url))
+        .json(&AttachRequest {
+            queue_id: "test",
+            topic: "/foo",
+        })
+        .send()?
+        .error_for_status()?;
+
+    client
+        .post(format!("{}/publish", base_url))
+        .json(&PublishRequest {
+            topic: "/foo/bar",
+            data: "hello",
+        })
+        .send()?
+        .error_for_status()?;
+
+    client
+        .post(format!("{}/publish", base_url))
+        .json(&PublishRequest {
+            topic: "/bar",
+            data: "noop",
+        })
+        .send()?
+        .error_for_status()?;
+
+    let resp = client
+        .get(format!("{}/get?queueId=test", base_url))
+        .send()?
+        .error_for_status()?;
+    let body: GetResponse = resp.json()?;
+    if body.messages.len() != 1 {
+        return Err("expected one message".into());
+    }
+    let msg = &body.messages[0];
+    if msg.topic != "/foo/bar" || msg.data != Value::String("hello".into()) {
+        return Err("message content mismatch".into());
+    }
+    Ok(())
 }
 
 fn main() {
@@ -29,6 +93,12 @@ fn main() {
     let url = args[1].clone();
     let threads: usize = args[2].parse().expect("invalid threads");
     let messages: usize = args[3].parse().expect("invalid messages");
+
+    if let Err(e) = run_basic_test(&url) {
+        eprintln!("basic test failed: {}", e);
+        return;
+    }
+    println!("basic functionality test passed");
 
     let times: Arc<Mutex<Vec<u128>>> = Arc::new(Mutex::new(Vec::new()));
     let mut handles = Vec::new();


### PR DESCRIPTION
## Summary
- update README to note the new basic test
- update tester dependencies
- extend tester to run a functional test covering topics and message content before the load test

## Testing
- `cargo check` *(fails: failed to download from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686b6fe061508328b452bb4db6c8cacc