### PR TITLE
Add Java broker implementation

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,46 @@
+# Java Broker Example
+
+This folder contains a minimal message broker implemented in Java using the Javalin framework.
+
+## Running
+
+Build and start the server with:
+
+```sh
+mvn -f java/pom.xml package
+java -jar java/target/java-broker-1.0-SNAPSHOT-shaded.jar
+```
+
+Alternatively, if you have a plugin to run directly:
+
+```sh
+mvn -f java/pom.xml exec:java -Dexec.mainClass=thinbroker.BrokerServer
+```
+
+## API
+
+The API matches the TypeScript and Rust implementations:
+
+### POST /publish
+
+Body JSON:
+
+```
+{ "topic": "/topic/sub", "data": { ... } }
+```
+
+Publishes a message. Queues attached to the topic or any parent topic receive the message.
+
+### POST /attachQueue
+
+Body JSON:
+
+```
+{ "queueId": "myQueue", "topic": "/topic" }
+```
+
+Registers a queue to receive messages from a topic.
+
+### GET /get?queueId=myQueue
+
+Retrieves and clears messages for the specified queue.

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,0 +1,43 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>thinbroker</groupId>
+    <artifactId>java-broker</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>io.javalin</groupId>
+            <artifactId>javalin</artifactId>
+            <version>5.6.2</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>thinbroker.BrokerServer</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/java/src/main/java/thinbroker/BrokerServer.java
+++ b/java/src/main/java/thinbroker/BrokerServer.java
@@ -1,0 +1,101 @@
+package thinbroker;
+
+import io.javalin.Javalin;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.*;
+
+public class BrokerServer {
+    static class Message {
+        public String topic;
+        public JsonNode data;
+        Message(String topic, JsonNode data) {
+            this.topic = topic;
+            this.data = data;
+        }
+    }
+
+    static class Queue {
+        List<String> topic;
+        List<Message> messages = new ArrayList<>();
+        Queue(List<String> topic) { this.topic = topic; }
+    }
+
+    static class Broker {
+        Map<String, Queue> queues = new HashMap<>();
+
+        void attachQueue(String id, String topic) {
+            List<String> segments = parseTopic(topic);
+            queues.put(id, new Queue(segments));
+        }
+
+        void publish(String topic, JsonNode data) {
+            List<String> segments = parseTopic(topic);
+            for (Queue q : queues.values()) {
+                if (topicMatches(q.topic, segments)) {
+                    q.messages.add(new Message(topic, data));
+                }
+            }
+        }
+
+        List<Message> getMessages(String id) {
+            Queue q = queues.get(id);
+            if (q == null) return Collections.emptyList();
+            List<Message> out = new ArrayList<>(q.messages);
+            q.messages.clear();
+            return out;
+        }
+
+        static List<String> parseTopic(String topic) {
+            String[] parts = topic.split("/");
+            List<String> segs = new ArrayList<>();
+            for (String p : parts) {
+                if (!p.isEmpty()) segs.add(p);
+            }
+            return segs;
+        }
+
+        static boolean topicMatches(List<String> queueTopic, List<String> messageTopic) {
+            if (queueTopic.size() > messageTopic.size()) return false;
+            for (int i = 0; i < queueTopic.size(); i++) {
+                if (!queueTopic.get(i).equals(messageTopic.get(i))) return false;
+            }
+            return true;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Broker broker = new Broker();
+        ObjectMapper mapper = new ObjectMapper();
+
+        int port = Integer.parseInt(System.getenv().getOrDefault("PORT", "3000"));
+        Javalin app = Javalin.create(config -> {}).start(port);
+
+        app.post("/publish", ctx -> {
+            JsonNode body = mapper.readTree(ctx.body());
+            String topic = body.get("topic").asText();
+            JsonNode data = body.get("data");
+            broker.publish(topic, data);
+            ctx.json(Map.of("status", "ok"));
+        });
+
+        app.post("/attachQueue", ctx -> {
+            JsonNode body = mapper.readTree(ctx.body());
+            String queueId = body.get("queueId").asText();
+            String topic = body.get("topic").asText();
+            broker.attachQueue(queueId, topic);
+            ctx.json(Map.of("status", "ok"));
+        });
+
+        app.get("/get", ctx -> {
+            String id = ctx.queryParam("queueId");
+            if (id == null) {
+                ctx.status(400).json(Map.of("error", "Missing queueId"));
+                return;
+            }
+            List<Message> msgs = broker.getMessages(id);
+            ctx.json(Map.of("messages", msgs));
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- implement Java version of the broker using Javalin
- add pom file with shading to produce runnable jar
- document how to run the Java broker

## Testing
- `npm run build` in `typescript`
- `mvn -f java/pom.xml -DskipTests package` *(fails: `mvn: command not found`)*
- `cargo build --manifest-path rust/Cargo.toml` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_686b72ed38fc83289d3f3c9db54b97dd