### PR TITLE
Fix Java build dependency

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -15,6 +15,11 @@
             <artifactId>javalin</artifactId>
             <version>5.6.2</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>


### PR DESCRIPTION
## Summary
- add Jackson Databind to Java broker dependencies

## Testing
- `mvn -f java/pom.xml -q package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686b7450afb883289c8fa388766c714b