### PR TITLE
Update Rust broker run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm start
 ### Rust
 
 ```sh
-cargo run --manifest-path rust/Cargo.toml
+cargo run --release --manifest-path rust/Cargo.toml
 ```
 
 ### Go

--- a/article.md
+++ b/article.md
@@ -22,7 +22,7 @@ npm start
 
 ```bash
 # Rust
-cargo run --manifest-path rust/Cargo.toml
+cargo run --release --manifest-path rust/Cargo.toml
 ```
 
 ```bash

--- a/rust/README.md
+++ b/rust/README.md
@@ -7,7 +7,7 @@ This folder contains a minimal message broker implemented in Rust using the `act
 Build and start the server with:
 
 ```sh
-cargo run --manifest-path rust/Cargo.toml
+cargo run --release --manifest-path rust/Cargo.toml
 ```
 
 ## API


### PR DESCRIPTION
## Summary
- run the Rust broker in release mode

## Testing
- `cargo check --manifest-path rust/Cargo.toml` *(fails: failed to download from index.crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_686bc1102b8483289bdd78f7d33603b7